### PR TITLE
Added 'Questions' and 'Stay in touch' sections to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ https://lansingcodes.github.io/sign-in-sheet/
 
 All participants are expected to treat others with respect and follow our [Code of Conduct](https://www.lansing.codes/code-of-conduct/).
 
+## Instructions
+
+Anything appearing in red (including this message) will not appear in the printed version of this page.
+
+Type your event name in the red box to the right of the logo. It will be centered correctly in the print version.
+
+The print version is styled to look best with 1" margins on all sides of the page and no headers or footers.
+
+You can also choose how many pages to print and whether to show line numbers using the form at the top of the page.
+
 ## Questions
 
 For general support, direct your questions to the
@@ -21,13 +31,3 @@ project is exclusively for bug reports and feature requests.
 -   [Facebook](https://www.facebook.com/lansingcodes)
 -   [Website](https://www.lansing.codes)
 -   [Newsletter](http://bit.ly/lansing-codes-newsletter)
-
-## Instructions
-
-Anything appearing in red (including this message) will not appear in the printed version of this page.
-
-Type your event name in the red box to the right of the logo. It will be centered correctly in the print version.
-
-The print version is styled to look best with 1" margins on all sides of the page and no headers or footers.
-
-You can also choose how many pages to print and whether to show line numbers using the form at the top of the page.


### PR DESCRIPTION
Pulled the `Questions` and `Stay in touch` sections from the www repository and included them in the sign-in-sheet readme. 

Fixes #6 